### PR TITLE
[feat] #31 좋아요 통신

### DIFF
--- a/app/src/main/java/org/sopt/app3/planfit/core/common/ViewModelFactory.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/core/common/ViewModelFactory.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.ViewModelProvider
 import org.sopt.app3.planfit.data.ServicePool
 import org.sopt.app3.planfit.data.repo.ExerciseListRepositoryImpl
 import org.sopt.app3.planfit.data.repo.ExerciseMainRepositoryImpl
+import org.sopt.app3.planfit.data.repo.LikeRepoImpl
 import org.sopt.app3.planfit.presentation.exerciselist.ExerciseViewModel
+import org.sopt.app3.planfit.presentation.exercisemain.LikeViewModel
 import org.sopt.app3.planfit.presentation.exercisemain.ExerciseMainViewModel
 import org.sopt.app3.planfit.presentation.provider.ResourceProviderImpl
 
@@ -16,6 +18,9 @@ class ViewModelFactory : ViewModelProvider.Factory {
         }
         else if(modelClass.isAssignableFrom(ExerciseMainViewModel::class.java)) {
             return ExerciseMainViewModel(ExerciseMainRepositoryImpl(ServicePool.exerciseMainService)) as T
+        }
+        else if(modelClass.isAssignableFrom(LikeViewModel::class.java)) {
+            return LikeViewModel(LikeRepoImpl(ServicePool.likeService)) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")
     }

--- a/app/src/main/java/org/sopt/app3/planfit/data/ApiFactory.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/data/ApiFactory.kt
@@ -8,6 +8,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.sopt.app3.planfit.BuildConfig
 import org.sopt.app3.planfit.data.api.ExerciseListService
 import org.sopt.app3.planfit.data.api.ExerciseMainService
+import org.sopt.app3.planfit.data.api.LikeService
 import org.sopt.app3.planfit.data.interceptor.AuthInterceptor
 import retrofit2.Retrofit
 
@@ -36,4 +37,5 @@ object ApiFactory {
 object ServicePool {
     val exerciseListService by lazy { ApiFactory.create<ExerciseListService>() }
     val exerciseMainService by lazy { ApiFactory.create<ExerciseMainService>() }
+    val likeService by lazy { ApiFactory.create<LikeService>() }
 }

--- a/app/src/main/java/org/sopt/app3/planfit/data/api/LikeService.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/data/api/LikeService.kt
@@ -1,0 +1,17 @@
+package org.sopt.app3.planfit.data.api
+
+import org.sopt.app3.planfit.data.model.response.base.BaseResponse
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+
+interface LikeService {
+    @PATCH("/api/v1/exercises/{exerciseId}/like")
+    suspend fun patchLike(
+        @Path("exerciseId") exerciseId: Long
+    ) : BaseResponse<Unit>
+
+    @PATCH("/api/v1/exercises/{exerciseId}/unlike")
+    suspend fun patchUnlike(
+        @Path("exerciseId") exerciseId: Long
+    ) : BaseResponse<Unit>
+}

--- a/app/src/main/java/org/sopt/app3/planfit/data/repo/LikeRepoImpl.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/data/repo/LikeRepoImpl.kt
@@ -1,0 +1,16 @@
+package org.sopt.app3.planfit.data.repo
+
+import org.sopt.app3.planfit.data.api.LikeService
+import org.sopt.app3.planfit.domain.repo.LikeRepo
+
+class LikeRepoImpl(private val likeService: LikeService) : LikeRepo{
+    override suspend fun changeToLike(exerciseId: Long): Result<Unit> =
+        runCatching {
+            likeService.patchLike(exerciseId)
+        }
+
+    override suspend fun changeToUnLike(exerciseId: Long): Result<Unit> =
+        runCatching {
+            likeService.patchUnlike(exerciseId)
+        }
+}

--- a/app/src/main/java/org/sopt/app3/planfit/domain/repo/LikeRepo.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/domain/repo/LikeRepo.kt
@@ -1,0 +1,6 @@
+package org.sopt.app3.planfit.domain.repo
+
+interface LikeRepo {
+    suspend fun changeToLike(exerciseId: Long) : Result<Unit>
+    suspend fun changeToUnLike(exerciseId: Long) : Result<Unit>
+}

--- a/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/ExerciseMainActivity.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/ExerciseMainActivity.kt
@@ -1,7 +1,9 @@
 package org.sopt.app3.planfit.presentation.exercisemain
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
+import androidx.lifecycle.viewmodel.viewModelFactory
 import coil.ImageLoader
 import coil.decode.ImageDecoderDecoder
 import coil.load
@@ -14,7 +16,9 @@ import org.sopt.app3.planfit.presentation.exercisemain.adapter.SetListAdapter
 class ExerciseMainActivity : BaseActivity<ActivityExerciseMainBinding>({ inflater ->
     ActivityExerciseMainBinding.inflate(inflater)
 }) {
-    private val viewModel: ExerciseMainViewModel by viewModels { ViewModelFactory() }
+    private val mainViewModel: ExerciseMainViewModel by viewModels { ViewModelFactory() }
+    private val likeViewModel: LikeViewModel by viewModels { ViewModelFactory() }
+
     private lateinit var adapter: SetListAdapter
     private var lastIndex = 5
     private var startIndex = 1
@@ -28,7 +32,7 @@ class ExerciseMainActivity : BaseActivity<ActivityExerciseMainBinding>({ inflate
         adapter = SetListAdapter()
 
         binding.rvExerciseMainSet.adapter = adapter
-        adapter.submitList(viewModel.setList.value)
+        adapter.submitList(mainViewModel.setList.value)
 
         binding.rvExerciseMainSet.itemAnimator = null // 화면 깜빡임 방지
         binding.tvExerciseMainComplete.text = getString(R.string.exercise_main_complete)
@@ -39,20 +43,20 @@ class ExerciseMainActivity : BaseActivity<ActivityExerciseMainBinding>({ inflate
 
     private fun addSet() {
         binding.tvExerciseMainAdd.setOnClickListener {
-            viewModel.addExerciseSet(lastIndex++.toLong())
+            mainViewModel.addExerciseSet(lastIndex++.toLong())
         }
-        viewModel.setList.observe(this) {
+        mainViewModel.setList.observe(this) {
             adapter.submitList(it)
         }
     }
 
     private fun completeSet() {
         binding.tvExerciseMainComplete.setOnClickListener {
-            viewModel.completeExerciseSet(startIndex++.toLong())
+            mainViewModel.completeExerciseSet(startIndex++.toLong())
         }
 
-        viewModel.currentIndex.observe(this) {
-            adapter.submitList(viewModel.setList.value)
+        mainViewModel.currentIndex.observe(this) {
+            adapter.submitList(mainViewModel.setList.value)
             adapter.notifyItemChanged((it - 1).toInt())
             adapter.notifyItemChanged(it.toInt())
 
@@ -74,6 +78,11 @@ class ExerciseMainActivity : BaseActivity<ActivityExerciseMainBinding>({ inflate
         with(binding.ivExerciseMainHeart) {
             setOnClickListener {
                 isSelected = !isSelected
+
+                if(isSelected)
+                    likeViewModel.changeToLike(1)
+                else
+                    likeViewModel.changeToUnlike(1)
             }
         }
     }

--- a/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/ExerciseMainActivity.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/ExerciseMainActivity.kt
@@ -53,6 +53,13 @@ class ExerciseMainActivity : BaseActivity<ActivityExerciseMainBinding>({ inflate
     private fun completeSet() {
         binding.tvExerciseMainComplete.setOnClickListener {
             mainViewModel.completeExerciseSet(startIndex++.toLong())
+
+            if(startIndex == lastIndex-1)
+                binding.tvExerciseMainComplete.isEnabled = false
+        }
+
+        mainViewModel.setList.observe(this) {
+            binding.tvExerciseMainComplete.isEnabled = true
         }
 
         mainViewModel.currentIndex.observe(this) {

--- a/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/LikeViewModel.kt
+++ b/app/src/main/java/org/sopt/app3/planfit/presentation/exercisemain/LikeViewModel.kt
@@ -1,0 +1,36 @@
+package org.sopt.app3.planfit.presentation.exercisemain
+
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.sopt.app3.planfit.domain.repo.LikeRepo
+
+class LikeViewModel(private val likeRepo: LikeRepo) : ViewModel() {
+    private val _likeStatus = MutableLiveData(false)
+
+    fun changeToLike(id: Long) {
+        viewModelScope.launch {
+            likeRepo.changeToLike(id)
+                .onSuccess {
+                    _likeStatus.value = true
+                }
+                .onFailure {
+                    Log.e("change status fail", it.message.toString())
+                }
+        }
+    }
+
+    fun changeToUnlike(id: Long) {
+        viewModelScope.launch {
+            likeRepo.changeToUnLike(id)
+                .onSuccess {
+                    _likeStatus.value = false
+                }
+                .onFailure {
+                    Log.e("change status fail", it.message.toString())
+                }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
좋아요 통신

🌱 작업한 내용
- 좋아요 등록 및 취소 api 연결
- 추가로 서버에서 세트 추가가 안되어 있을 때 세트 완료 버튼을 누르면 완료 상태로 안 바뀌어서 세트 완료할 때 추가된 세트가 없을 경우에 세트 추가 후 완료를 하도록 하였습니다!
-> 근데 이럴 경우 세트 완료 누르면 `indexoutofboundsexception` 에러 발생하더라구요 그래서 startIndex랑 lastIndex 비교해서 버튼 비활성화 처리하도록 했습니다!

## 📸 스크린샷
|스크린샷|
|:--:|

https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-Android/assets/102652293/2b88e2a0-175d-4669-bf9c-baf06a40fc69




## 📮 관련 이슈
- Resolved: #31 
